### PR TITLE
feat: Adding --obscure flat to config get and export

### DIFF
--- a/docs/cli/elhaz-config-get.rst
+++ b/docs/cli/elhaz-config-get.rst
@@ -23,6 +23,14 @@ Options
 ``--name``, ``-n`` *NAME*
    Config name. If omitted, an interactive selection prompt is shown.
 
+``--obscure``, ``-o``
+   Redact sensitive field values in the output. Affected fields include
+   ``RoleArn``, ``ExternalId``, ``SerialNumber``, ``TokenCode``,
+   ``PolicyArns``, and any static AWS credentials
+   (``aws_access_key_id``, ``aws_secret_access_key``, ``aws_session_token``,
+   ``aws_account_id``). Redacted values are replaced with ``***``.
+   Off by default.
+
 ``--help``
    Show help message and exit.
 
@@ -40,3 +48,9 @@ Select a config interactively:
 .. code-block:: bash
 
    elhaz config get
+
+Print a config with sensitive values hidden (e.g. for screen sharing):
+
+.. code-block:: bash
+
+   elhaz config get -n prod --obscure

--- a/docs/cli/elhaz-export.rst
+++ b/docs/cli/elhaz-export.rst
@@ -41,6 +41,12 @@ Options
 ``--format``, ``-f`` ``json`` | ``env`` | ``credential-process``
    Output format. Default: ``json``.
 
+``--obscure``, ``-o``
+   Redact sensitive credential values in the output. The ``access_key``,
+   ``secret_key``, and ``token`` fields are replaced with ``***``. The
+   ``expiry_time`` field is not affected. Applies to all output formats.
+   Off by default.
+
 ``--help``
    Show help message and exit.
 
@@ -65,3 +71,9 @@ Use elhaz as an AWS ``credential_process`` provider in ``~/.aws/config``:
 
    [profile my-role]
    credential_process = elhaz export -n prod -f credential-process
+
+Export credentials with sensitive values hidden (e.g. for screen sharing):
+
+.. code-block:: bash
+
+   elhaz export -n prod --obscure

--- a/elhaz/cli/__main__.py
+++ b/elhaz/cli/__main__.py
@@ -31,7 +31,7 @@ from elhaz.models import CredentialProcessModel
 from ..constants import state
 from .config import app as _config_app
 from .daemon import app as _daemon_app
-from .output import print_error, print_json
+from .output import obscure, print_error, print_json
 from .prompts import ask_yes_no, resolve_name
 
 app_help_text = """
@@ -174,6 +174,12 @@ def export_cmd(
         "-f",
         help="Output format: json | env | credential-process.",
     ),
+    obscure_values: bool = typer.Option(
+        False,
+        "--obscure",
+        "-o",
+        help="Redact sensitive credential values in output.",
+    ),
 ) -> None:
     """Export credentials for the specified config.
 
@@ -188,6 +194,9 @@ def export_cmd(
 
     name = resolve_name(name, state, message="Select a config:")
     creds = _fetch_credentials(name)
+
+    if obscure_values:
+        creds = obscure(creds)
 
     if fmt == ExportFormat.json:
         print_json(creds)

--- a/elhaz/cli/config.py
+++ b/elhaz/cli/config.py
@@ -20,7 +20,7 @@ from elhaz.exceptions import (
 )
 
 from ..constants import state
-from .output import print_error, print_json, print_success
+from .output import obscure, print_error, print_json, print_success
 from .prompts import (
     ask_text,
     ask_yes_no,
@@ -388,6 +388,12 @@ def config_get(
     name: Optional[str] = typer.Option(
         None, "--name", "-n", help="Config name."
     ),
+    obscure_values: bool = typer.Option(
+        False,
+        "--obscure",
+        "-o",
+        help="Redact sensitive field values (RoleArn, credentials, etc.).",
+    ),
 ) -> None:
     """Return config details as formatted JSON."""
 
@@ -414,7 +420,10 @@ def config_get(
         raise typer.Exit(0)
 
     try:
-        print_json(cfg.get())
+        data = cfg.get()
+        if obscure_values:
+            data = obscure(data)
+        print_json(data)
     except ElhazNotFoundError as exc:
         print_error(str(exc))
         raise typer.Exit(1)

--- a/elhaz/cli/output.py
+++ b/elhaz/cli/output.py
@@ -15,6 +15,63 @@ from pygments.lexers import JsonLexer
 
 _FORMATTER = Terminal256Formatter(style="monokai")
 
+_REDACTED = "***"
+
+#: Field names whose values are redacted when ``--obscure`` is requested.
+#: Covers credential-bearing and ARN-bearing fields across ConfigModel
+#: sections (AssumeRole, STS, Session) and the raw export credential dict.
+SENSITIVE_FIELDS: frozenset[str] = frozenset(
+    {
+        # AssumeRole — contains account ID or shared secrets
+        "RoleArn",
+        "ExternalId",
+        "SerialNumber",
+        "TokenCode",
+        "PolicyArns",
+        # STS / Session — static credentials supplied to boto3
+        "aws_access_key_id",
+        "aws_secret_access_key",
+        "aws_session_token",
+        "aws_account_id",
+        # Raw export credential keys returned by the daemon
+        "access_key",
+        "secret_key",
+        "token",
+        # credential-process JSON shape (CredentialProcessModel)
+        "AccessKeyId",
+        "SecretAccessKey",
+        "SessionToken",
+    }
+)
+
+
+def obscure(data: Any) -> Any:
+    """Recursively redact sensitive field values in *data*.
+
+    Traverses dicts and lists. Any dict key present in
+    :data:`SENSITIVE_FIELDS` has its value replaced with ``"***"``.
+    All other values are returned unchanged.
+
+    Parameters
+    ----------
+    data : Any
+        JSON-serializable value, typically a ``dict`` or ``list``.
+
+    Returns
+    -------
+    Any
+        A new structure with sensitive values replaced by ``"***"``.
+    """
+
+    if isinstance(data, dict):
+        return {
+            k: _REDACTED if k in SENSITIVE_FIELDS else obscure(v)
+            for k, v in data.items()
+        }
+    if isinstance(data, list):
+        return [obscure(item) for item in data]
+    return data
+
 
 def print_json(data: Any) -> None:
     """Pretty-print *data* as syntax-highlighted JSON.

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -99,6 +99,38 @@ def test_config_get_invalid_yaml_exits_1(
     assert result.exit_code == 1
 
 
+def test_config_get_obscure_redacts_role_arn(
+    monkeypatch, tmp_constants: Constants
+) -> None:
+    _inject_state(monkeypatch, tmp_constants)
+    _write_config(tmp_constants, "demo")
+    result = runner.invoke(app, ["get", "--name", "demo", "--obscure"])
+    assert result.exit_code == 0
+    assert ROLE_ARN not in result.output
+    assert "***" in result.output
+
+
+def test_config_get_obscure_short_flag(
+    monkeypatch, tmp_constants: Constants
+) -> None:
+    _inject_state(monkeypatch, tmp_constants)
+    _write_config(tmp_constants, "demo")
+    result = runner.invoke(app, ["get", "-n", "demo", "-o"])
+    assert result.exit_code == 0
+    assert ROLE_ARN not in result.output
+    assert "***" in result.output
+
+
+def test_config_get_without_obscure_shows_role_arn(
+    monkeypatch, tmp_constants: Constants
+) -> None:
+    _inject_state(monkeypatch, tmp_constants)
+    _write_config(tmp_constants, "demo")
+    result = runner.invoke(app, ["get", "--name", "demo"])
+    assert result.exit_code == 0
+    assert ROLE_ARN in result.output
+
+
 def test_config_remove_missing_file_exits_1(
     monkeypatch, tmp_constants: Constants
 ) -> None:

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -398,3 +398,44 @@ def test_whoami_non_404_error_exits_1(monkeypatch) -> None:
     result = runner.invoke(app, ["whoami", "--name", "demo"])
     assert result.exit_code == 1
     assert "internal error" in result.output
+
+
+def test_export_obscure_json_redacts_credentials(monkeypatch) -> None:
+    _install_fake_client(monkeypatch, [ok_response(data=FAKE_CREDS)])
+    result = runner.invoke(app, ["export", "--name", "demo", "--obscure"])
+    assert result.exit_code == 0
+    assert "AKIATEST" not in result.output
+    assert "SUPERSECRET" not in result.output
+    assert "TOKEN123" not in result.output
+    assert "***" in result.output
+    # expiry_time is not sensitive — it must still appear
+    assert "2030-01-01T00:00:00Z" in result.output
+
+
+def test_export_obscure_short_flag(monkeypatch) -> None:
+    _install_fake_client(monkeypatch, [ok_response(data=FAKE_CREDS)])
+    result = runner.invoke(app, ["export", "-n", "demo", "-o"])
+    assert result.exit_code == 0
+    assert "AKIATEST" not in result.output
+    assert "***" in result.output
+
+
+def test_export_obscure_env_format_redacts_values(monkeypatch) -> None:
+    _install_fake_client(monkeypatch, [ok_response(data=FAKE_CREDS)])
+    result = runner.invoke(
+        app, ["export", "--name", "demo", "--format", "env", "--obscure"]
+    )
+    assert result.exit_code == 0
+    assert "AKIATEST" not in result.output
+    assert "SUPERSECRET" not in result.output
+    assert "TOKEN123" not in result.output
+    assert "AWS_ACCESS_KEY_ID=***" in result.output
+    assert "AWS_SECRET_ACCESS_KEY=***" in result.output
+    assert "AWS_SESSION_TOKEN=***" in result.output
+
+
+def test_export_without_obscure_shows_credentials(monkeypatch) -> None:
+    _install_fake_client(monkeypatch, [ok_response(data=FAKE_CREDS)])
+    result = runner.invoke(app, ["export", "--name", "demo"])
+    assert result.exit_code == 0
+    assert "AKIATEST" in result.output

--- a/tests/test_cli_output.py
+++ b/tests/test_cli_output.py
@@ -9,7 +9,13 @@ from __future__ import annotations
 import datetime
 import json
 
-from elhaz.cli.output import print_error, print_json, print_success
+from elhaz.cli.output import (
+    SENSITIVE_FIELDS,
+    obscure,
+    print_error,
+    print_json,
+    print_success,
+)
 
 
 def test_print_json_non_tty_outputs_plain_json(capsys) -> None:
@@ -82,3 +88,114 @@ def test_print_success_nothing_to_stderr(capsys) -> None:
     print_success("done")
     captured = capsys.readouterr()
     assert captured.err == ""
+
+
+# ---------------------------------------------------------------------------
+# obscure()
+# ---------------------------------------------------------------------------
+
+
+def test_obscure_redacts_role_arn() -> None:
+    data = {"AssumeRole": {"RoleArn": "arn:aws:iam::123456789012:role/Dev"}}
+    result = obscure(data)
+    assert result["AssumeRole"]["RoleArn"] == "***"
+
+
+def test_obscure_redacts_credentials() -> None:
+    data = {
+        "aws_access_key_id": "AKIATEST",
+        "aws_secret_access_key": "SECRET",
+        "aws_session_token": "TOKEN",
+    }
+    result = obscure(data)
+    assert result["aws_access_key_id"] == "***"
+    assert result["aws_secret_access_key"] == "***"
+    assert result["aws_session_token"] == "***"
+
+
+def test_obscure_redacts_export_credential_keys() -> None:
+    data = {
+        "access_key": "AKIATEST",
+        "secret_key": "SUPERSECRET",
+        "token": "TOKEN123",
+        "expiry_time": "2030-01-01T00:00:00Z",
+    }
+    result = obscure(data)
+    assert result["access_key"] == "***"
+    assert result["secret_key"] == "***"
+    assert result["token"] == "***"
+    assert result["expiry_time"] == "2030-01-01T00:00:00Z"
+
+
+def test_obscure_passes_through_non_sensitive_fields() -> None:
+    data = {
+        "region_name": "us-east-1",
+        "RoleSessionName": "my-session",
+        "DurationSeconds": 3600,
+    }
+    result = obscure(data)
+    assert result == data
+
+
+def test_obscure_handles_nested_dicts() -> None:
+    data = {
+        "STS": {
+            "region_name": "us-west-2",
+            "aws_secret_access_key": "SECRET",
+        }
+    }
+    result = obscure(data)
+    assert result["STS"]["region_name"] == "us-west-2"
+    assert result["STS"]["aws_secret_access_key"] == "***"
+
+
+def test_obscure_handles_list_of_dicts() -> None:
+    data = {
+        "PolicyArns": [
+            "arn:aws:iam::123456789012:policy/Foo",
+            "arn:aws:iam::123456789012:policy/Bar",
+        ]
+    }
+    result = obscure(data)
+    assert result["PolicyArns"] == "***"
+
+
+def test_obscure_handles_non_dict_non_list_passthrough() -> None:
+    assert obscure("hello") == "hello"
+    assert obscure(42) == 42
+    assert obscure(None) is None
+
+
+def test_obscure_returns_new_object_does_not_mutate() -> None:
+    data = {
+        "RoleArn": "arn:aws:iam::123456789012:role/Dev",
+        "region": "us-east-1",
+    }
+    original = dict(data)
+    obscure(data)
+    assert data == original
+
+
+def test_sensitive_fields_is_frozenset() -> None:
+    assert isinstance(SENSITIVE_FIELDS, frozenset)
+
+
+def test_sensitive_fields_covers_key_names() -> None:
+    expected = {
+        "RoleArn",
+        "ExternalId",
+        "SerialNumber",
+        "TokenCode",
+        "PolicyArns",
+        "aws_access_key_id",
+        "aws_secret_access_key",
+        "aws_session_token",
+        "aws_account_id",
+        "access_key",
+        "secret_key",
+        "token",
+        "AccessKeyId",
+        "SecretAccessKey",
+        "SessionToken",
+    }
+    assert expected.issubset(SENSITIVE_FIELDS)


### PR DESCRIPTION
## All submissions

* [x] Does your pull request title follow Conventional Commits (`type(scope)!: summary`)?
    * Allowed `type` values in this repository: `feat`, `fix`, `perf`, `refactor`, `docs`, `style`, `test`, `build`, `ci`, `chore`, `revert`.
    * Example pull request title: `fix(cache): add a new parameter to Client`.
    * For breaking changes in PR titles, use `!` before `:` (example: `feat!: remove deprecated cache API`).
    * You can find additional details [here](https://www.conventionalcommits.org/en/v1.0.0/#summary).
    * Release Please uses these commit types to determine release bumps (`feat` -> minor, `fix`/`perf` -> patch, `!` -> major).
    * You can skip releases by adding '[skip release]' into the PR title.
    * You can specify alpha and beta versions by adding something like `Release-As: 0.1.0b1` in the footer of the PR body.
* [x] Did you verify that your changes pass pre-commit checks before opening this pull request?
    * The pre-commit checks are identical to required status checks for pull requests in this repository. Know that suppressing pre-commit checks via the `--no-verify` | `-nv` arguments will not help you avoid the PR status checks!
    * To ensure that pre-commit checks work on your branch before running `git commit`, run `pre-commit install` and `pre-commit install-hooks` beforehand. 
    * If needed, run the full suite locally with `pre-commit run --all-files`.
* [x] Have you checked that your changes don't relate to other open pull requests?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## New feature submissions

* [x] Does your new feature include documentation? If not, why not?
    * [x] Does that documentation match the numpydoc guidelines?
    * [x] Did you locally test your documentation changes using `uv run --directory docs make clean html` from the root directory?
* [x] Did you write unit tests for the new feature? If not, why not?
    * [x] Did the unit tests pass?

## Submission details

The following PR adds an optional `--obscure/-o` flag to `elhaz config get` and `elhaz export` so that sensitive values are hidden in stdout, enabling safe and secure presentation and demo'ing.