### PR TITLE
feat: Extending --obscure flag to whoami

### DIFF
--- a/docs/cli/elhaz-whoami.rst
+++ b/docs/cli/elhaz-whoami.rst
@@ -27,6 +27,10 @@ Options
 ``--name``, ``-n`` *NAME*
    Config name. If omitted, an interactive selection prompt is shown.
 
+``--obscure``, ``-o``
+   Redact sensitive identity values in the output. The ``Account``, ``Arn``,
+   and ``UserId`` fields are replaced with ``***``. Off by default.
+
 ``--help``
    Show help message and exit.
 
@@ -48,3 +52,9 @@ Example output:
      "Account": "123456789012",
      "Arn": "arn:aws:sts::123456789012:assumed-role/MyRole/session-name"
    }
+
+Check identity with sensitive values hidden (e.g. for screen sharing):
+
+.. code-block:: bash
+
+   elhaz whoami -n prod --obscure

--- a/docs/concepts/daemon.rst
+++ b/docs/concepts/daemon.rst
@@ -76,3 +76,8 @@ How do I remove a config from the daemon?
 -----------------------------------------
 
 Check the docs for :ref:`elhaz config remove <elhaz-config-remove>`.
+
+How do I see which AWS sessions are currently active in the daemon?
+-------------------------------------------------------------------
+
+Check the docs for :ref:`elhaz daemon list <elhaz-daemon-list>`.

--- a/elhaz/cli/__main__.py
+++ b/elhaz/cli/__main__.py
@@ -342,6 +342,12 @@ def whoami_cmd(
     name: Optional[str] = typer.Option(
         None, "--name", "-n", help="Config name."
     ),
+    obscure_values: bool = typer.Option(
+        False,
+        "--obscure",
+        "-o",
+        help="Redact sensitive identity values (Account, Arn, UserId).",
+    ),
 ) -> None:
     """Return the STS caller identity for the specified config."""
 
@@ -374,7 +380,7 @@ def whoami_cmd(
                     )
                     print_error(msg)
                     raise typer.Exit(1)
-                whoami_cmd(name=name)
+                whoami_cmd(name=name, obscure_values=obscure_values)
                 return
         else:
             msg = (
@@ -383,7 +389,10 @@ def whoami_cmd(
             print_error(msg)
         raise typer.Exit(1)
 
-    print_json(response.data)
+    data = response.data
+    if obscure_values:
+        data = obscure(data)
+    print_json(data)
 
 
 def main() -> None:

--- a/elhaz/cli/output.py
+++ b/elhaz/cli/output.py
@@ -41,6 +41,10 @@ SENSITIVE_FIELDS: frozenset[str] = frozenset(
         "AccessKeyId",
         "SecretAccessKey",
         "SessionToken",
+        # STS GetCallerIdentity (whoami) response fields
+        "Account",
+        "Arn",
+        "UserId",
     }
 )
 

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -400,6 +400,47 @@ def test_whoami_non_404_error_exits_1(monkeypatch) -> None:
     assert "internal error" in result.output
 
 
+def test_whoami_obscure_redacts_identity(monkeypatch) -> None:
+    _install_fake_client(monkeypatch, [ok_response(data=FAKE_IDENTITY)])
+    result = runner.invoke(app, ["whoami", "--name", "demo", "--obscure"])
+    assert result.exit_code == 0
+    assert "123456789012" not in result.output
+    assert "AROATEST" not in result.output
+    assert "***" in result.output
+
+
+def test_whoami_obscure_short_flag(monkeypatch) -> None:
+    _install_fake_client(monkeypatch, [ok_response(data=FAKE_IDENTITY)])
+    result = runner.invoke(app, ["whoami", "-n", "demo", "-o"])
+    assert result.exit_code == 0
+    assert "123456789012" not in result.output
+    assert "***" in result.output
+
+
+def test_whoami_without_obscure_shows_identity(monkeypatch) -> None:
+    _install_fake_client(monkeypatch, [ok_response(data=FAKE_IDENTITY)])
+    result = runner.invoke(app, ["whoami", "--name", "demo"])
+    assert result.exit_code == 0
+    assert "123456789012" in result.output
+
+
+def test_whoami_obscure_propagates_through_auto_add(monkeypatch) -> None:
+    """--obscure is preserved through the 404 → add → retry path."""
+    _install_fake_client(
+        monkeypatch,
+        [
+            err_response(404, "no session"),
+            ok_response(data={"config": "demo"}),
+            ok_response(data=FAKE_IDENTITY),
+        ],
+    )
+    monkeypatch.setattr("elhaz.cli.__main__.ask_yes_no", lambda *a, **k: True)
+    result = runner.invoke(app, ["whoami", "--name", "demo", "--obscure"])
+    assert result.exit_code == 0
+    assert "123456789012" not in result.output
+    assert "***" in result.output
+
+
 def test_export_obscure_json_redacts_credentials(monkeypatch) -> None:
     _install_fake_client(monkeypatch, [ok_response(data=FAKE_CREDS)])
     result = runner.invoke(app, ["export", "--name", "demo", "--obscure"])

--- a/tests/test_cli_output.py
+++ b/tests/test_cli_output.py
@@ -197,5 +197,8 @@ def test_sensitive_fields_covers_key_names() -> None:
         "AccessKeyId",
         "SecretAccessKey",
         "SessionToken",
+        "Account",
+        "Arn",
+        "UserId",
     }
     assert expected.issubset(SENSITIVE_FIELDS)


### PR DESCRIPTION
## All submissions

* [ ] Does your pull request title follow Conventional Commits (`type(scope)!: summary`)?
    * Allowed `type` values in this repository: `feat`, `fix`, `perf`, `refactor`, `docs`, `style`, `test`, `build`, `ci`, `chore`, `revert`.
    * Example pull request title: `fix(cache): add a new parameter to Client`.
    * For breaking changes in PR titles, use `!` before `:` (example: `feat!: remove deprecated cache API`).
    * You can find additional details [here](https://www.conventionalcommits.org/en/v1.0.0/#summary).
    * Release Please uses these commit types to determine release bumps (`feat` -> minor, `fix`/`perf` -> patch, `!` -> major).
    * You can skip releases by adding '[skip release]' into the PR title.
    * You can specify alpha and beta versions by adding something like `Release-As: 0.1.0b1` in the footer of the PR body.
* [ ] Did you verify that your changes pass pre-commit checks before opening this pull request?
    * The pre-commit checks are identical to required status checks for pull requests in this repository. Know that suppressing pre-commit checks via the `--no-verify` | `-nv` arguments will not help you avoid the PR status checks!
    * To ensure that pre-commit checks work on your branch before running `git commit`, run `pre-commit install` and `pre-commit install-hooks` beforehand. 
    * If needed, run the full suite locally with `pre-commit run --all-files`.
* [ ] Have you checked that your changes don't relate to other open pull requests?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## New feature submissions

* [ ] Does your new feature include documentation? If not, why not?
    * [ ] Does that documentation match the numpydoc guidelines?
    * [ ] Did you locally test your documentation changes using `uv run --directory docs make clean html` from the root directory?
* [ ] Did you write unit tests for the new feature? If not, why not?
    * [ ] Did the unit tests pass?

## Submission details

The following PR extends the `--obscure/-o` flag to the `whoami` command for secure presentation-mode.