### PR TITLE
fix: Removing deadlock with client timeout

### DIFF
--- a/docs/cli/elhaz.rst
+++ b/docs/cli/elhaz.rst
@@ -38,6 +38,12 @@ Options
    Maximum number of sessions the daemon will retain in its LRU cache before
    evicting the least recently used entry. Default: ``10``.
 
+``--client-timeout``, ``-ct`` *FLOAT*
+   Seconds before a daemon client socket read or write times out. Prevents
+   callers from hanging indefinitely when the daemon is slow or a circular
+   ``credential_process`` reference causes a re-entrant request.
+   Default: ``30.0``.
+
 ``--help``
    Show help message and exit.
 

--- a/elhaz/cli/__main__.py
+++ b/elhaz/cli/__main__.py
@@ -90,6 +90,16 @@ def _callback(
         ),
         show_default=False,
     ),
+    client_timeout: Optional[float] = typer.Option(
+        None,
+        "--client-timeout",
+        "-ct",
+        help=(
+            "Seconds before a daemon client socket times out. "
+            f"Default: {Constants._client_timeout}"
+        ),
+        show_default=False,
+    ),
 ) -> None:
     """elhaz — manage refreshable AWS credentials."""
     if config_dir is not None:
@@ -102,6 +112,8 @@ def _callback(
         state.max_unix_socket_connections = max_unix_socket_connections
     if max_daemon_cache_size is not None:
         state.max_daemon_cache_size = max_daemon_cache_size
+    if client_timeout is not None:
+        state.client_timeout = client_timeout
 
 
 def _fetch_credentials(name: str) -> dict:

--- a/elhaz/cli/daemon.py
+++ b/elhaz/cli/daemon.py
@@ -114,6 +114,8 @@ def _daemon_subprocess_cmd() -> list[str]:
         str(state.max_unix_socket_connections),
         "--max-daemon-cache-size",
         str(state.max_daemon_cache_size),
+        "--client-timeout",
+        str(state.client_timeout),
         "daemon",
         "_serve",
     ]

--- a/elhaz/constants.py
+++ b/elhaz/constants.py
@@ -32,6 +32,11 @@ class Constants:
     max_daemon_cache_size : int
         The maximum number of sessions the daemon session cache will retain
         before evicting the least recently used entry. Default is 10.
+    client_timeout : float
+        Seconds before a ``Client`` socket read or write gives up waiting for
+        the daemon. Prevents callers from hanging indefinitely when the daemon
+        is slow or a circular ``credential_process`` reference causes a
+        re-entrant request. Default is 30.0.
     """
 
     _config_dir: Path = Path.home() / ".elhaz/configs"
@@ -40,6 +45,7 @@ class Constants:
     _daemon_logging_path: Path = Path.home() / ".elhaz/logs/daemon.log"
     _max_unix_socket_connections: int = 5
     _max_daemon_cache_size: int = 10
+    _client_timeout: float = 30.0
 
     @property
     def config_dir(self) -> Path:
@@ -100,6 +106,16 @@ class Constants:
                 f"Invalid max daemon cache size: '{value}'"
             )
         self._max_daemon_cache_size = value
+
+    @property
+    def client_timeout(self) -> float:
+        return self._client_timeout
+
+    @client_timeout.setter
+    def client_timeout(self, value: float) -> None:
+        if not isinstance(value, (int, float)) or value <= 0:
+            raise ElhazValidationError(f"Invalid client timeout: '{value}'")
+        self._client_timeout = float(value)
 
 
 state = Constants()

--- a/elhaz/daemon.py
+++ b/elhaz/daemon.py
@@ -120,6 +120,11 @@ class DaemonService:
     def add(self, config: str) -> Dict[str, str]:
         """Initialize and cache a new session for a named config.
 
+        Session construction happens outside the lock because it may invoke
+        external processes (e.g. a ``credential_process`` entry in an AWS
+        profile) that themselves connect back to the daemon.  Holding the
+        lock during that call would deadlock those nested requests.
+
         Parameters
         ----------
         config : str
@@ -131,8 +136,9 @@ class DaemonService:
             Confirmation payload containing the config name.
         """
 
+        session = Session(config)
         with self._lock:
-            self._cache[config] = Session(config)
+            self._cache[config] = session
             return {"config": config}
 
     def credentials(self, config: str) -> Dict[str, Any]:
@@ -651,6 +657,7 @@ class Client:
 
     def __init__(self, constants: Constants) -> None:
         self._sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self._sock.settimeout(constants.client_timeout)
         try:
             self._sock.connect(str(constants.socket_path))
         except OSError as exc:


### PR DESCRIPTION
## All submissions

* [x] Does your pull request title follow Conventional Commits (`type(scope)!: summary`)?
    * Allowed `type` values in this repository: `feat`, `fix`, `perf`, `refactor`, `docs`, `style`, `test`, `build`, `ci`, `chore`, `revert`.
    * Example pull request title: `fix(cache): add a new parameter to Client`.
    * For breaking changes in PR titles, use `!` before `:` (example: `feat!: remove deprecated cache API`).
    * You can find additional details [here](https://www.conventionalcommits.org/en/v1.0.0/#summary).
    * Release Please uses these commit types to determine release bumps (`feat` -> minor, `fix`/`perf` -> patch, `!` -> major).
    * You can skip releases by adding '[skip release]' into the PR title.
    * You can specify alpha and beta versions by adding something like `Release-As: 0.1.0b1` in the footer of the PR body.
* [x] Did you verify that your changes pass pre-commit checks before opening this pull request?
    * The pre-commit checks are identical to required status checks for pull requests in this repository. Know that suppressing pre-commit checks via the `--no-verify` | `-nv` arguments will not help you avoid the PR status checks!
    * To ensure that pre-commit checks work on your branch before running `git commit`, run `pre-commit install` and `pre-commit install-hooks` beforehand. 
    * If needed, run the full suite locally with `pre-commit run --all-files`.
* [x] Have you checked that your changes don't relate to other open pull requests?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## New feature submissions

* [x] Does your new feature include documentation? If not, why not?
    * [x] Does that documentation match the numpydoc guidelines?
    * [x] Did you locally test your documentation changes using `uv run --directory docs make clean html` from the root directory?
* [ ] Did you write unit tests for the new feature? If not, why not?
    * [ ] Did the unit tests pass?

## Submission details

The following PR fixes a deadlock issue where circular relationships between AWS profiles and elhaz cause infinite recursion. The solution, in this case, includes initializing an AWS session outside of a thread lock and, crucially, including a `Client` timeout constant which can be configured by the elhaz CLI.